### PR TITLE
Fix config defaults for URL and timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var defaults = {
-    url: "http://api.jotform.com",
+    url: "https://api.jotform.com",
     apiKey: undefined,
     version: "latest",
     debug: false,
-    timeout: null
+    timeout: 10000 // 10 seconds
 }
 
 var _url = defaults.url

--- a/jotform-api.js
+++ b/jotform-api.js
@@ -1,8 +1,9 @@
 var defaults = {
-    url: "http://api.jotform.com",
+    url: "https://api.jotform.com",
     apiKey: undefined,
     version: "latest",
-    debug: false
+    debug: false,
+    timeout: 10000 // 10 seconds
 }
 
 var _url = defaults.url


### PR DESCRIPTION
Fix configuration defaults:

- `url` now uses HTTPS to be secure-by-default
- `timeout` is now required for running on newer versions of node, see #22

Resolves #22 