### PR TITLE
Update content-type header in client.ts:postForm

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -52,7 +52,7 @@ export default class Client {
   postForm(url: string, body?: Json, config?: RequestConfig): JotformResponse {
     return this.inner.post(url, body, {...config, headers: {
       ...config?.headers,
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     }});
   }
 


### PR DESCRIPTION
Updating content-type header in postForm client call to resolve issue where webhook urls are being encoded causing jotform api call to fail with a 400 bad request due to bad webhook url caused by url encoding.